### PR TITLE
Remove openrave_catkin as hard dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,6 @@ if(${openrave_catkin_FOUND})
       DESTINATION "${CATKIN_PACKAGE_SHARE_DESTINATION}/data"
   )
 else(${openrave_catkin_FOUND})
-  message(WARNING "Unable to find openrave_catkin. You will have to manually"
+  message(AUTHOR_WARNING "Unable to find openrave_catkin. You will have to manually"
                   " add these models to your OpenRAVE_DATA path.")
 endif(${openrave_catkin_FOUND})

--- a/package.xml
+++ b/package.xml
@@ -11,5 +11,4 @@
   <maintainer email="mkoval@cs.cmu.edu">Michael Koval</maintainer>
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>openrave_catkin</build_depend>
 </package>


### PR DESCRIPTION
This is an optional dependency. And leaving it in breaks auto-builds on xenial and bionic (where pr-openrave doesn't exist as a package).

Also downgrade openrave missing warning to AUTHOR_WARNING so users can suppress it easily.