### PR TITLE
Add inertial and color tags for wheelchair.urdf

### DIFF
--- a/data/furniture/wheelchair.urdf
+++ b/data/furniture/wheelchair.urdf
@@ -1,14 +1,22 @@
 <?xml version="1.0" ?>
 <robot name="wheelchair">
     <link name="base_link">
+        <inertial>
+            <mass value="5" />
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0.070968" ixy="-0.009135" ixz="-0.000056" iyy="0.048896" iyz="0.000007" izz="0.086415" />
+        </inertial>
         <visual>
             <geometry>
-                <mesh filename="wheelchair.dae" scale="1 1 1"/>
+                <mesh filename="package://pr_assets/data/furniture/wheelchair.dae" scale="1 1 1"/>
             </geometry>
+            <material name="aluminium">
+                <color rgba="${211/255} ${211/255} ${211/255} 1.0"/>
+            </material>
         </visual>
         <collision>
             <geometry>
-                <mesh filename="wheelchair_collision.stl" scale="1 1 1"/>
+                <mesh filename="package://pr_assets/data/furniture/wheelchair_collision.stl" scale="1 1 1"/>
             </geometry>
         </collision>
     </link>


### PR DESCRIPTION
This PR modifies the wheelchair asset to include information needed for simulation:
1. Adds `<inertial>` tag with approximated inertia computed using convex hull
2. Changes mesh relative paths to direct paths
3. Adds material/color tags